### PR TITLE
Re-fixed bad album id in comment seed data

### DIFF
--- a/server/seeds.js
+++ b/server/seeds.js
@@ -101,7 +101,7 @@ module.exports = {
 
     [{
       author: 'Evan Willum',
-      album_id: 9,
+      album_id: 10,
       message: 'Good album, but I liked the first one.',
     }].map(saveComment);
   },


### PR DESCRIPTION
This was previously set to `9` in 5eb665c, but I believe it was correct the first time.
